### PR TITLE
Add Fetching and Storing of Data from the SpaceX API's Missions Endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "space-travelers-hub",
       "version": "0.1.0",
       "dependencies": {
+        "@reduxjs/toolkit": "^1.9.5",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -3098,6 +3099,29 @@
           "optional": true
         },
         "webpack-plugin-serve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.5.tgz",
+      "integrity": "sha512-Rt97jHmfTeaxL4swLRNPD/zV4OxTes4la07Xc4hetpUW/vc75t5m1ANyxG6ymnEQ2FsLQsoMlYB2vV1sO3m8tQ==",
+      "dependencies": {
+        "immer": "^9.0.21",
+        "redux": "^4.2.1",
+        "redux-thunk": "^2.4.2",
+        "reselect": "^4.1.8"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react-redux": "^7.2.1 || ^8.0.2"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
           "optional": true
         }
       }
@@ -16058,12 +16082,28 @@
         "node": ">=8"
       }
     },
+    "node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
     "node_modules/redux-logger": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/redux-logger/-/redux-logger-3.0.6.tgz",
       "integrity": "sha512-JoCIok7bg/XpqA1JqCqXFypuqBbQzGQySrhFzewB7ThcnysTO30l4VCst86AuB9T9tuT03MAA56Jw2PNhRSNCg==",
       "dependencies": {
         "deep-diff": "^0.3.5"
+      }
+    },
+    "node_modules/redux-thunk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
+      "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
+      "peerDependencies": {
+        "redux": "^4"
       }
     },
     "node_modules/regenerate": {
@@ -16252,6 +16292,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+    },
+    "node_modules/reselect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
+      "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ=="
     },
     "node_modules/resolve": {
       "version": "1.22.2",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@reduxjs/toolkit": "^1.9.5",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,8 @@
 import './App.css';
 import React from 'react';
+import { Provider } from 'react-redux';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import store from './redux/store';
 import Navbar from './components/Navbar';
 import Profile from './pages/Profile';
 import Rocket from './pages/Rocket';
@@ -8,14 +10,16 @@ import Mission from './pages/Mission';
 
 function App() {
   return (
-    <Router>
-      <Navbar />
-      <Routes>
-        <Route exact path="/" element={<Rocket />} />
-        <Route exact path="/missions" element={<Mission />} />
-        <Route exact path="/profile" element={<Profile />} />
-      </Routes>
-    </Router>
+    <Provider store={store}>
+      <Router>
+        <Navbar />
+        <Routes>
+          <Route exact path="/" element={<Rocket />} />
+          <Route exact path="/missions" element={<Mission />} />
+          <Route exact path="/profile" element={<Profile />} />
+        </Routes>
+      </Router>
+    </Provider>
   );
 }
 

--- a/src/App.js
+++ b/src/App.js
@@ -1,25 +1,30 @@
 import './App.css';
-import React from 'react';
-import { Provider } from 'react-redux';
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
-import store from './redux/store';
+import React, { useEffect } from 'react';
+import { Routes, Route } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
 import Navbar from './components/Navbar';
 import Profile from './pages/Profile';
 import Rocket from './pages/Rocket';
 import Mission from './pages/Mission';
+import { fetchMissions } from './redux/mission/missionSlice';
 
 function App() {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(fetchMissions());
+  }, [dispatch]);
+
   return (
-    <Provider store={store}>
-      <Router>
-        <Navbar />
-        <Routes>
-          <Route exact path="/" element={<Rocket />} />
-          <Route exact path="/missions" element={<Mission />} />
-          <Route exact path="/profile" element={<Profile />} />
-        </Routes>
-      </Router>
-    </Provider>
+    <>
+      <Navbar />
+      <Routes>
+        <Route exact path="/" element={<Rocket />} />
+        <Route exact path="/missions" element={<Mission />} />
+        <Route exact path="/profile" element={<Profile />} />
+      </Routes>
+    </>
+
   );
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,18 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { Provider } from 'react-redux';
+import { BrowserRouter as Router } from 'react-router-dom';
+import store from './redux/store';
 import './index.css';
 import App from './App';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
+    <Provider store={store}>
+      <Router>
+        <App />
+      </Router>
+    </Provider>
   </React.StrictMode>,
 );

--- a/src/pages/Mission.js
+++ b/src/pages/Mission.js
@@ -1,14 +1,9 @@
-import React, { useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import { fetchMissions, selectMissions } from '../redux/mission/missionSlice';
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { selectMissions } from '../redux/mission/missionSlice';
 
 const Mission = () => {
-  const dispatch = useDispatch();
   const missions = useSelector(selectMissions);
-
-  useEffect(() => {
-    dispatch(fetchMissions());
-  }, [dispatch]);
 
   return (
     <div>

--- a/src/pages/Mission.js
+++ b/src/pages/Mission.js
@@ -1,9 +1,25 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { fetchMissions, selectMissions } from '../redux/mission/missionSlice';
 
-const Mission = () => (
-  <div>
-    This is the Mission page.
-  </div>
-);
+const Mission = () => {
+  const dispatch = useDispatch();
+  const missions = useSelector(selectMissions);
+
+  useEffect(() => {
+    dispatch(fetchMissions());
+  }, [dispatch]);
+
+  return (
+    <div>
+      {missions.map((mission) => (
+        <div key={mission.mission_id}>
+          <h2>{mission.mission_name}</h2>
+          <p>{mission.description}</p>
+        </div>
+      ))}
+    </div>
+  );
+};
 
 export default Mission;

--- a/src/redux/mission/missionSlice.js
+++ b/src/redux/mission/missionSlice.js
@@ -1,0 +1,39 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+
+export const fetchMissions = createAsyncThunk('missions/fetchMissions', async () => {
+  const response = await fetch('https://api.spacexdata.com/v3/missions');
+  const data = await response.json();
+  return data;
+});
+
+const missionSlice = createSlice({
+  name: 'missions',
+  initialState: {
+    missions: [],
+    status: 'idle',
+    error: null,
+  },
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchMissions.pending, (state) => {
+        state.status = 'loading';
+      })
+      .addCase(fetchMissions.fulfilled, (state, action) => {
+        state.status = 'succeeded';
+        state.missions = action.payload.map((mission) => ({
+          mission_id: mission.mission_id,
+          mission_name: mission.mission_name,
+          description: mission.description,
+        }));
+      })
+      .addCase(fetchMissions.rejected, (state, action) => {
+        state.status = 'failed';
+        state.error = action.error.message;
+      });
+  },
+});
+
+export const selectMissions = (state) => state.missions.missions;
+
+export default missionSlice.reducer;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,0 +1,10 @@
+import { configureStore } from '@reduxjs/toolkit';
+import missionReducer from './mission/missionSlice';
+
+const store = configureStore({
+  reducer: {
+    missions: missionReducer,
+  },
+});
+
+export default store;


### PR DESCRIPTION
This PR adds functionality to fetch data from the Missions endpoint (https://api.spacexdata.com/v3/missions) and store the selected data in the Redux store. The data includes mission_id, mission_name, and description. This will only happen once when a user navigates to the Missions section and will not occur on every re-render.

### Changes Made
- Added code to `src/pages/Mission.js` to fetch data from the Missions endpoint and store it in the Redux store.
- Modified code in `src/redux/mission/missionSlice.js` to include the new data fields.
- Modified code in `src/App.js` to include the Missions section.
- Added `src/redux/store.js` file.

Please review and merge this PR once approved.
